### PR TITLE
Remove hardcoded API key from consensus utils

### DIFF
--- a/k_llms/resources/completions/completions.py
+++ b/k_llms/resources/completions/completions.py
@@ -69,11 +69,21 @@ class Completions:
             call_params["n"] = n
             completion = self._wrapper.client.chat.completions.create(**call_params)
             # The completion will have multiple choices, consolidate them
-            return consolidate_chat_completions(completion, embeddings_wrapper)
+            return consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
         else:
             # Single request - wrap in KLLMsChatCompletion
             completion = self._wrapper.client.chat.completions.create(**call_params)
-            return consolidate_chat_completions(completion, embeddings_wrapper)
+            return consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
 
     def parse(
         self,
@@ -122,11 +132,23 @@ class Completions:
             call_params["n"] = n
             completion = self._wrapper.client.beta.chat.completions.parse(**call_params)
             # The completion will have multiple choices, consolidate them
-            return consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
         else:
             # Single request - wrap in KLLMsParsedChatCompletion
             completion = self._wrapper.client.beta.chat.completions.parse(**call_params)
-            return consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
 
 
 class AsyncCompletions:
@@ -189,11 +211,21 @@ class AsyncCompletions:
             call_params["n"] = n
             completion = await self._wrapper.client.chat.completions.create(**call_params)
             # The completion will have multiple choices, consolidate them
-            return await async_consolidate_chat_completions(completion, embeddings_wrapper)
+            return await async_consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
         else:
             # Single request - wrap in KLLMsChatCompletion
             completion = await self._wrapper.client.chat.completions.create(**call_params)
-            return await async_consolidate_chat_completions(completion, embeddings_wrapper)
+            return await async_consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
 
     async def parse(
         self,
@@ -245,8 +277,20 @@ class AsyncCompletions:
             call_params["n"] = n
             completion = await self._wrapper.client.beta.chat.completions.parse(**call_params)
             # The completion will have multiple choices, consolidate them
-            return await async_consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return await async_consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )
         else:
             # Single request - wrap in KLLMsParsedChatCompletion
             completion = await self._wrapper.client.beta.chat.completions.parse(**call_params)
-            return await async_consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return await async_consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                api_key=self._wrapper.client.api_key,
+                base_url=self._wrapper.client.base_url,
+            )

--- a/k_llms/utils/consensus_utils.py
+++ b/k_llms/utils/consensus_utils.py
@@ -973,8 +973,14 @@ def voting_consensus(
 ###############################################################################
 # 6) Non-enum primitives (or treated as primitives) => pairwise similarity "center"
 ###############################################################################
-def string_consensus_llm(values: list[str]) -> str:
-    with OpenAI(api_key="AIzaSyAkHc8uVjIUMlfaTACfcOLYeV7F9PFOtak", base_url="https://generativelanguage.googleapis.com/v1beta/openai/") as client:
+def string_consensus_llm(values: list[str], api_key: str | None = None, base_url: str | None = None) -> str:
+    client_params: dict[str, str] = {}
+    if api_key is not None:
+        client_params["api_key"] = api_key
+    if base_url is not None:
+        client_params["base_url"] = base_url
+
+    with OpenAI(**client_params) as client:
         system_prompt = """
 You are a helpful assistant that builds a consensus string from a list of strings.
 ## Context
@@ -1013,7 +1019,7 @@ I think you got the point.
 """
         values_json_dumped = [json.dumps(v) for v in values]
         response = client.chat.completions.create(
-            model="gemini-2.0-flash-lite",
+            model="gpt-4.1-mini",
             messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": f"Input: {values_json_dumped}\nOutput:"}],
         )
         if response.choices[0].message.content is None:
@@ -1027,6 +1033,8 @@ def consensus_as_primitive(
     consensus_settings: ConsensusSettings,
     sync_get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[Any, float]:
     non_none_values = [v for v in values if v is not None]
     if len(non_none_values) == 0:
@@ -1038,7 +1046,7 @@ def consensus_as_primitive(
     first_val_type = type(non_none_values[0])
     if first_val_type is str and consensus_settings.string_consensus_method == "llm-consensus" and consensus_settings.string_similarity_method == "embeddings":
         # Feed an LLM with the values and ask it to build the consensus string
-        consensus_string = string_consensus_llm(non_none_values)
+        consensus_string = string_consensus_llm(non_none_values, api_key=api_key, base_url=base_url)
         # Compute the similarity between the consensus string and the values
         similarities = [generic_similarity(consensus_string, v, consensus_settings.string_similarity_method, sync_get_openai_embeddings_from_text) for v in non_none_values]
         confidence = float(np.nanmean(similarities))
@@ -1101,6 +1109,8 @@ def consensus_dict(
     consensus_settings: ConsensusSettings,
     sync_get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[dict, dict[str, float]]:
     """
     Returns (merged_dict, confidence_dict).
@@ -1122,7 +1132,14 @@ def consensus_dict(
             # We skip reasoning and quote fields on consensus.
             continue
         else:
-            val, conf = consensus_values(sub_vals, consensus_settings, sync_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+            val, conf = consensus_values(
+                sub_vals,
+                consensus_settings,
+                sync_get_openai_embeddings_from_text,
+                parent_valid_frac=parent_valid_frac,
+                api_key=api_key,
+                base_url=base_url,
+            )
             result[key] = val
             confs[key] = conf
 
@@ -1134,6 +1151,8 @@ def consensus_list(
     consensus_settings: ConsensusSettings,
     sync_get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[list[Any], list[float | dict]]:
     """
     - We do element-wise merging, calling consensus_value on each index.
@@ -1161,7 +1180,14 @@ def consensus_list(
     confidences = []
     for i in range(maximum_len):
         items = [(model_list[i] if i < len(model_list) else None) for model_list in list_values]
-        val_i, conf_i = consensus_values(items, consensus_settings, sync_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        val_i, conf_i = consensus_values(
+            items,
+            consensus_settings,
+            sync_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
         final_list.append(val_i)
         confidences.append(conf_i)
 
@@ -1194,6 +1220,8 @@ def consensus_values(
     consensus_settings: ConsensusSettings,
     sync_get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[Any, float | list[float | dict] | dict[str, float]]:
     """
     Decide which consensus function to call:
@@ -1232,7 +1260,14 @@ def consensus_values(
         total_valid = len(dicts_only)
         parent_valid_frac *= total_valid / len(values)
 
-        return consensus_dict(dicts_only, consensus_settings, sync_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        return consensus_dict(
+            dicts_only,
+            consensus_settings,
+            sync_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
     # If we have a list of values, recursively process them
     if isinstance(non_none_values[0], list):
@@ -1241,13 +1276,27 @@ def consensus_values(
         total_valid = len(lists_only)
         parent_valid_frac *= total_valid / len(values)
 
-        return consensus_list(lists_only, consensus_settings, sync_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        return consensus_list(
+            lists_only,
+            consensus_settings,
+            sync_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
     # 4) Otherwise => standard primitive consensus
     parent_valid_frac *= len(non_none_values) / len(values)
     if sync_get_openai_embeddings_from_text is None:
         raise ValueError("sync_get_openai_embeddings_from_text is required for primitive consensus")
-    consensus_result, confidence = consensus_as_primitive(non_none_values, consensus_settings, sync_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+    consensus_result, confidence = consensus_as_primitive(
+        non_none_values,
+        consensus_settings,
+        sync_get_openai_embeddings_from_text,
+        parent_valid_frac=parent_valid_frac,
+        api_key=api_key,
+        base_url=base_url,
+    )
     return consensus_result, confidence
 
 
@@ -1437,6 +1486,8 @@ async def async_consensus_as_primitive(
     consensus_settings: ConsensusSettings,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[Any, float]:
     """Async version of consensus_as_primitive"""
 
@@ -1450,7 +1501,7 @@ async def async_consensus_as_primitive(
     first_val_type = type(non_none_values[0])
     if first_val_type is str and consensus_settings.string_consensus_method == "llm-consensus" and consensus_settings.string_similarity_method == "embeddings":
         # Feed an LLM with the values and ask it to build the consensus string
-        consensus_string = string_consensus_llm(non_none_values)
+        consensus_string = string_consensus_llm(non_none_values, api_key=api_key, base_url=base_url)
         # Compute the similarity between the consensus string and the values
         similarities = []
         for v in non_none_values:
@@ -1489,6 +1540,8 @@ async def async_consensus_dict(
     consensus_settings: ConsensusSettings,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[dict, dict[str, float]]:
     """
     Async version of consensus_dict.
@@ -1511,7 +1564,14 @@ async def async_consensus_dict(
             # We skip reasoning and quote fields on consensus.
             continue
         else:
-            val, conf = await async_consensus_values(sub_vals, consensus_settings, async_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+            val, conf = await async_consensus_values(
+                sub_vals,
+                consensus_settings,
+                async_get_openai_embeddings_from_text,
+                parent_valid_frac=parent_valid_frac,
+                api_key=api_key,
+                base_url=base_url,
+            )
             result[key] = val
             confs[key] = conf
 
@@ -1523,6 +1583,8 @@ async def async_consensus_list(
     consensus_settings: ConsensusSettings,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[list[Any], list[float | dict]]:
     """
     Async version of consensus_list.
@@ -1551,7 +1613,14 @@ async def async_consensus_list(
     confidences = []
     for i in range(maximum_len):
         items = [(model_list[i] if i < len(model_list) else None) for model_list in list_values]
-        val_i, conf_i = await async_consensus_values(items, consensus_settings, async_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        val_i, conf_i = await async_consensus_values(
+            items,
+            consensus_settings,
+            async_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
         final_list.append(val_i)
         confidences.append(conf_i)
 
@@ -1563,6 +1632,8 @@ async def async_consensus_values(
     consensus_settings: ConsensusSettings,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     parent_valid_frac: float = 1.0,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> tuple[Any, float | list[float | dict] | dict[str, float]]:
     """
     Async version of consensus_values.
@@ -1602,7 +1673,14 @@ async def async_consensus_values(
         total_valid = len(dicts_only)
         parent_valid_frac *= total_valid / len(values)
 
-        return await async_consensus_dict(dicts_only, consensus_settings, async_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        return await async_consensus_dict(
+            dicts_only,
+            consensus_settings,
+            async_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
     # If we have a list of values, recursively process them
     if isinstance(non_none_values[0], list):
@@ -1611,14 +1689,26 @@ async def async_consensus_values(
         total_valid = len(lists_only)
         parent_valid_frac *= total_valid / len(values)
 
-        return await async_consensus_list(lists_only, consensus_settings, async_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac)
+        return await async_consensus_list(
+            lists_only,
+            consensus_settings,
+            async_get_openai_embeddings_from_text,
+            parent_valid_frac=parent_valid_frac,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
     # 4) Otherwise => standard primitive consensus
     parent_valid_frac *= len(non_none_values) / len(values)
     if async_get_openai_embeddings_from_text is None:
         raise ValueError("async_get_openai_embeddings_from_text is required for primitive consensus")
     consensus_result, confidence = await async_consensus_as_primitive(
-        non_none_values, consensus_settings, async_get_openai_embeddings_from_text, parent_valid_frac=parent_valid_frac
+        non_none_values,
+        consensus_settings,
+        async_get_openai_embeddings_from_text,
+        parent_valid_frac=parent_valid_frac,
+        api_key=api_key,
+        base_url=base_url,
     )
     return consensus_result, confidence
 

--- a/k_llms/utils/consolidation.py
+++ b/k_llms/utils/consolidation.py
@@ -63,6 +63,8 @@ def consolidate_chat_completions(
     completions: Union[List[ChatCompletion], ChatCompletion],
     get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> KLLMsChatCompletion:
     """
     Consolidate multiple ChatCompletion objects or a single ChatCompletion with multiple choices into a single KLLMsChatCompletion with consensus.
@@ -90,7 +92,13 @@ def consolidate_chat_completions(
             if choice.message.content:
                 choice_contents.append(_safe_parse_content(choice.message.content))
 
-        consensus_content, likelihoods = consensus_values(choice_contents, consensus_settings, get_openai_embeddings_from_text)
+        consensus_content, likelihoods = consensus_values(
+            choice_contents,
+            consensus_settings,
+            get_openai_embeddings_from_text,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
         # Create consolidated message
         # Convert consensus content to JSON string for message content
@@ -140,7 +148,13 @@ def consolidate_chat_completions(
             if completion.choices and completion.choices[0].message.content:
                 completion_contents.append(_safe_parse_content(completion.choices[0].message.content))
 
-        consensus_content, likelihoods = consensus_values(completion_contents, consensus_settings, get_openai_embeddings_from_text)
+        consensus_content, likelihoods = consensus_values(
+            completion_contents,
+            consensus_settings,
+            get_openai_embeddings_from_text,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
         # Use the first completion as the base
         base_completion = completion_list[0]
@@ -186,6 +200,8 @@ async def async_consolidate_chat_completions(
     completion: ChatCompletion,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> KLLMsChatCompletion:
     """
     Async version of consolidate_chat_completions.
@@ -216,7 +232,13 @@ async def async_consolidate_chat_completions(
             if choice.message.content:
                 async_choice_contents.append(_safe_parse_content(choice.message.content))
 
-        consensus_content, likelihoods = await async_consensus_values(async_choice_contents, consensus_settings, async_get_openai_embeddings_from_text)
+        consensus_content, likelihoods = await async_consensus_values(
+            async_choice_contents,
+            consensus_settings,
+            async_get_openai_embeddings_from_text,
+            api_key=api_key,
+            base_url=base_url,
+        )
 
         # Create consolidated message
         # Convert consensus content to JSON string for message content
@@ -257,6 +279,8 @@ def consolidate_parsed_chat_completions(
     get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
     response_format: Optional[type[ResponseFormatT]] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> KLLMsParsedChatCompletion:
     """
     Consolidate multiple choices in a ParsedChatCompletion object into a single KLLMsParsedChatCompletion with consensus.
@@ -283,7 +307,13 @@ def consolidate_parsed_chat_completions(
         if choice.message.content:
             parsed_choice_contents.append(_safe_parse_content(choice.message.content))
 
-    consensus_content, likelihoods = consensus_values(parsed_choice_contents, consensus_settings, get_openai_embeddings_from_text)
+    consensus_content, likelihoods = consensus_values(
+        parsed_choice_contents,
+        consensus_settings,
+        get_openai_embeddings_from_text,
+        api_key=api_key,
+        base_url=base_url,
+    )
 
     # Parse the consensus content if response_format is a BaseModel
     parsed_consensus = None
@@ -336,6 +366,8 @@ async def async_consolidate_parsed_chat_completions(
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
     response_format: Optional[type[ResponseFormatT]] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> KLLMsParsedChatCompletion:
     """
     Async version of consolidate_parsed_chat_completions.
@@ -363,7 +395,13 @@ async def async_consolidate_parsed_chat_completions(
         if choice.message.content:
             async_parsed_choice_contents.append(_safe_parse_content(choice.message.content))
 
-    consensus_content, likelihoods = await async_consensus_values(async_parsed_choice_contents, consensus_settings, async_get_openai_embeddings_from_text)
+    consensus_content, likelihoods = await async_consensus_values(
+        async_parsed_choice_contents,
+        consensus_settings,
+        async_get_openai_embeddings_from_text,
+        api_key=api_key,
+        base_url=base_url,
+    )
 
     # Parse the consensus content if response_format is a BaseModel
     parsed_consensus = None


### PR DESCRIPTION
## Summary
- Use client-supplied API key and base URL for consensus LLM
- Thread API key/base URL through consolidation helpers and completion wrappers
- Switch consensus model to gpt-4.1-mini

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6895c14909308333adb23eaded4d426c