### PR TITLE
Remove hardcoded API key from consensus utils

### DIFF
--- a/k_llms/resources/completions/completions.py
+++ b/k_llms/resources/completions/completions.py
@@ -69,11 +69,19 @@ class Completions:
             call_params["n"] = n
             completion = self._wrapper.client.chat.completions.create(**call_params)
             # The completion will have multiple choices, consolidate them
-            return consolidate_chat_completions(completion, embeddings_wrapper)
+            return consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                client=self._wrapper.client,
+            )
         else:
             # Single request - wrap in KLLMsChatCompletion
             completion = self._wrapper.client.chat.completions.create(**call_params)
-            return consolidate_chat_completions(completion, embeddings_wrapper)
+            return consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                client=self._wrapper.client,
+            )
 
     def parse(
         self,
@@ -122,11 +130,21 @@ class Completions:
             call_params["n"] = n
             completion = self._wrapper.client.beta.chat.completions.parse(**call_params)
             # The completion will have multiple choices, consolidate them
-            return consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                client=self._wrapper.client,
+            )
         else:
             # Single request - wrap in KLLMsParsedChatCompletion
             completion = self._wrapper.client.beta.chat.completions.parse(**call_params)
-            return consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                client=self._wrapper.client,
+            )
 
 
 class AsyncCompletions:
@@ -189,11 +207,19 @@ class AsyncCompletions:
             call_params["n"] = n
             completion = await self._wrapper.client.chat.completions.create(**call_params)
             # The completion will have multiple choices, consolidate them
-            return await async_consolidate_chat_completions(completion, embeddings_wrapper)
+            return await async_consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                client=self._wrapper.client,
+            )
         else:
             # Single request - wrap in KLLMsChatCompletion
             completion = await self._wrapper.client.chat.completions.create(**call_params)
-            return await async_consolidate_chat_completions(completion, embeddings_wrapper)
+            return await async_consolidate_chat_completions(
+                completion,
+                embeddings_wrapper,
+                client=self._wrapper.client,
+            )
 
     async def parse(
         self,
@@ -245,8 +271,18 @@ class AsyncCompletions:
             call_params["n"] = n
             completion = await self._wrapper.client.beta.chat.completions.parse(**call_params)
             # The completion will have multiple choices, consolidate them
-            return await async_consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return await async_consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                client=self._wrapper.client,
+            )
         else:
             # Single request - wrap in KLLMsParsedChatCompletion
             completion = await self._wrapper.client.beta.chat.completions.parse(**call_params)
-            return await async_consolidate_parsed_chat_completions(completion, embeddings_wrapper, response_format=response_format)
+            return await async_consolidate_parsed_chat_completions(
+                completion,
+                embeddings_wrapper,
+                response_format=response_format,
+                client=self._wrapper.client,
+            )

--- a/k_llms/utils/consolidation.py
+++ b/k_llms/utils/consolidation.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Optional, Union, Sequence
+from openai import OpenAI
 from openai.types.chat import ChatCompletion, ParsedChatCompletion, ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
 from openai.types.chat.chat_completion import Choice
@@ -63,6 +64,7 @@ def consolidate_chat_completions(
     completions: Union[List[ChatCompletion], ChatCompletion],
     get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
+    client: OpenAI | None = None,
 ) -> KLLMsChatCompletion:
     """
     Consolidate multiple ChatCompletion objects or a single ChatCompletion with multiple choices into a single KLLMsChatCompletion with consensus.
@@ -90,7 +92,12 @@ def consolidate_chat_completions(
             if choice.message.content:
                 choice_contents.append(_safe_parse_content(choice.message.content))
 
-        consensus_content, likelihoods = consensus_values(choice_contents, consensus_settings, get_openai_embeddings_from_text)
+        consensus_content, likelihoods = consensus_values(
+            choice_contents,
+            consensus_settings,
+            get_openai_embeddings_from_text,
+            client=client,
+        )
 
         # Create consolidated message
         # Convert consensus content to JSON string for message content
@@ -140,7 +147,12 @@ def consolidate_chat_completions(
             if completion.choices and completion.choices[0].message.content:
                 completion_contents.append(_safe_parse_content(completion.choices[0].message.content))
 
-        consensus_content, likelihoods = consensus_values(completion_contents, consensus_settings, get_openai_embeddings_from_text)
+        consensus_content, likelihoods = consensus_values(
+            completion_contents,
+            consensus_settings,
+            get_openai_embeddings_from_text,
+            client=client,
+        )
 
         # Use the first completion as the base
         base_completion = completion_list[0]
@@ -186,6 +198,7 @@ async def async_consolidate_chat_completions(
     completion: ChatCompletion,
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
+    client: OpenAI | None = None,
 ) -> KLLMsChatCompletion:
     """
     Async version of consolidate_chat_completions.
@@ -216,7 +229,12 @@ async def async_consolidate_chat_completions(
             if choice.message.content:
                 async_choice_contents.append(_safe_parse_content(choice.message.content))
 
-        consensus_content, likelihoods = await async_consensus_values(async_choice_contents, consensus_settings, async_get_openai_embeddings_from_text)
+        consensus_content, likelihoods = await async_consensus_values(
+            async_choice_contents,
+            consensus_settings,
+            async_get_openai_embeddings_from_text,
+            client=client,
+        )
 
         # Create consolidated message
         # Convert consensus content to JSON string for message content
@@ -257,6 +275,7 @@ def consolidate_parsed_chat_completions(
     get_openai_embeddings_from_text: SYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
     response_format: Optional[type[ResponseFormatT]] = None,
+    client: OpenAI | None = None,
 ) -> KLLMsParsedChatCompletion:
     """
     Consolidate multiple choices in a ParsedChatCompletion object into a single KLLMsParsedChatCompletion with consensus.
@@ -283,7 +302,12 @@ def consolidate_parsed_chat_completions(
         if choice.message.content:
             parsed_choice_contents.append(_safe_parse_content(choice.message.content))
 
-    consensus_content, likelihoods = consensus_values(parsed_choice_contents, consensus_settings, get_openai_embeddings_from_text)
+    consensus_content, likelihoods = consensus_values(
+        parsed_choice_contents,
+        consensus_settings,
+        get_openai_embeddings_from_text,
+        client=client,
+    )
 
     # Parse the consensus content if response_format is a BaseModel
     parsed_consensus = None
@@ -336,6 +360,7 @@ async def async_consolidate_parsed_chat_completions(
     async_get_openai_embeddings_from_text: ASYNC_GET_OPENAI_EMBEDDINGS_FROM_TEXT_TYPE,
     consensus_settings: ConsensusSettings = ConsensusSettings(),
     response_format: Optional[type[ResponseFormatT]] = None,
+    client: OpenAI | None = None,
 ) -> KLLMsParsedChatCompletion:
     """
     Async version of consolidate_parsed_chat_completions.
@@ -363,7 +388,12 @@ async def async_consolidate_parsed_chat_completions(
         if choice.message.content:
             async_parsed_choice_contents.append(_safe_parse_content(choice.message.content))
 
-    consensus_content, likelihoods = await async_consensus_values(async_parsed_choice_contents, consensus_settings, async_get_openai_embeddings_from_text)
+    consensus_content, likelihoods = await async_consensus_values(
+        async_parsed_choice_contents,
+        consensus_settings,
+        async_get_openai_embeddings_from_text,
+        client=client,
+    )
 
     # Parse the consensus content if response_format is a BaseModel
     parsed_consensus = None


### PR DESCRIPTION
## Summary
- Thread OpenAI client through consensus utilities and consolidate helpers
- Remove API key/base URL parameters in favor of direct client usage
- Pass wrapper client to consolidation during completion handling

## Testing
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6895c14909308333adb23eaded4d426c